### PR TITLE
Adjust email change request email message

### DIFF
--- a/src/emails/templates/saleor/AccountChangeEmailRequestedEmail.tsx
+++ b/src/emails/templates/saleor/AccountChangeEmailRequestedEmail.tsx
@@ -20,18 +20,15 @@ const AccountChangeEmailRequestedEmail = ({
         <>
           <Header>Hi {data.user?.firstName}!</Header>
           <Text>
-            {
-              "Your email address change has been requested. If you want to confirm changing the email address"
-            }
-            {data.newEmail ? (
+            Your email address change has been requested. If you want to confirm
+            changing the email address
+            {data.newEmail && (
               <>
                 {" to "}
                 <strong>{data.newEmail}</strong>
-                {", please follow the link:"}
               </>
-            ) : (
-              ", please follow the link:"
             )}
+            , please follow the link:
             <br />
             <Link
               href={data.redirectUrl ?? "#"}

--- a/src/emails/templates/saleor/AccountChangeEmailRequestedEmail.tsx
+++ b/src/emails/templates/saleor/AccountChangeEmailRequestedEmail.tsx
@@ -20,9 +20,18 @@ const AccountChangeEmailRequestedEmail = ({
         <>
           <Header>Hi {data.user?.firstName}!</Header>
           <Text>
-            Your email address change has been requested. If you want to confirm
-            changing the email address to <strong>{data.newEmail}</strong>,
-            please follow the link:
+            {
+              "Your email address change has been requested. If you want to confirm changing the email address"
+            }
+            {data.newEmail ? (
+              <>
+                {" to "}
+                <strong>{data.newEmail}</strong>
+                {", please follow the link:"}
+              </>
+            ) : (
+              ", please follow the link:"
+            )}
             <br />
             <Link
               href={data.redirectUrl ?? "#"}


### PR DESCRIPTION
It adjust email change request email message - if `newEmail` value exists then it shows:

> "Your email address change has been requested. If you want to confirm changing the email address to {newEmail}, please follow the link:"

If there is no newEmail value:

> "Your email address change has been requested. If you want to confirm changing the email address, please follow the link:".
