### PR TITLE
Fix mismatched subtotal and delivery cost in Order placed email

### DIFF
--- a/src/emails/components/CostSummary.tsx
+++ b/src/emails/components/CostSummary.tsx
@@ -14,12 +14,12 @@ const CostSummary = ({
 
     <Row className="mb-2 mt-4">
       <Column align="left">Subtotal</Column>
-      <Column align="right">{delivery}</Column>
+      <Column align="right">{subtotal}</Column>
     </Row>
 
     <Row className="mb-4">
       <Column align="left">Delivery</Column>
-      <Column align="right">{subtotal}</Column>
+      <Column align="right">{delivery}</Column>
     </Row>
 
     <Hr />


### PR DESCRIPTION
It fixes mismatched cost of subtotal and delivery cost in Order placed email:
<img width="737" alt="image" src="https://github.com/user-attachments/assets/d10e5b2f-9d22-436f-9d5c-8769b6950769" />

